### PR TITLE
Fix imports of parse_data and parse_links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,7 @@ intersphinx_mapping = {
     'echo': ('https://echo.readthedocs.io/en/latest/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'PyQt5': ('https://www.riverbankcomputing.com/static/Docs/PyQt5/', None),
-    'glue': ('http://docs.glueviz.org/en/latest/', None),
+    'glue': ('http://glue-core.readthedocs.org/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -135,14 +135,22 @@ nitpick_ignore = [('py:obj', 'glue_qt.viewers.common.toolbar.BasicToolbar.insert
                   ('py:class', 'PyQt5.sip.voidptr'),
                   ('py:class', 'PYQT_SLOT')]
 
-nitpick_ignore_regex = [('py:class', r'PyQt5\.QtCore\.Q[A-Z][a-zA-Z]+'),
-                        ('py:class', r'PyQt5\.QtWidgets\.Q[A-Z][a-zA-Z]+'),
-                        ('py:class', r'PyQt6\.QtCore\.Q[A-Z][a-zA-Z]+'),
-                        ('py:class', r'PyQt6\.QtWidgets\.Q[A-Z][a-zA-Z]+'),
-                        ('py:class', r'Qt\.[A-Z][a-zA-Z]+'),
-                        ('py:class', r'QPalette\.[A-Z][a-zA-Z]+'),
-                        ('py:class', r'QWidget\.[A-Z][a-zA-Z]+'),
-                        ('py:class', r'Q[A-Z][a-zA-Z]+')]
+nitpick_ignore_regex = [('py:class', r'PyQt5\.QtCore\.Q[a-zA-Z]+'),
+                        ('py:class', r'PyQt5\.QtGui\.Q[a-zA-Z]+'),
+                        ('py:class', r'PyQt5\.QtWidgets\.Q[a-zA-Z]+'),
+                        ('py:class', r'PyQt6\.QtCore\.Q[a-zA-Z]+'),
+                        ('py:class', r'PyQt6\.QtGui\.Q[a-zA-Z]+'),
+                        ('py:class', r'PyQt6\.QtWidgets\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide2\.QtCore\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide2\.QtGui\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide2\.QtWidgets\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide6\.QtCore\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide6\.QtGui\.Q[a-zA-Z]+'),
+                        ('py:class', r'PySide6\.QtWidgets\.Q[a-zA-Z]+'),
+                        ('py:class', r'Qt\.[a-zA-Z]+'),
+                        ('py:class', r'QPalette\.[a-zA-Z]+'),
+                        ('py:class', r'QWidget\.[a-zA-Z]+'),
+                        ('py:class', r'Q[a-zA-Z]+')]
 
 # coax Sphinx into treating descriptors as attributes
 # see https://bitbucket.org/birkenfeld/sphinx/issue/1254/#comment-7587063

--- a/glue_qt/qglue.py
+++ b/glue_qt/qglue.py
@@ -9,13 +9,8 @@ Utility function to load a variety of python objects into glue
 import sys
 from contextlib import contextmanager
 
-try:
-    from glue.core import BaseData, Data
-    from glue.core.cli_parsers import parse_data, parse_links
-except ImportError:
-    # let qglue import, even though this won't work
-    # qglue will throw an ImportError
-    BaseData = Data = None
+from glue.core import BaseData, Data
+from glue.core.parsers import parse_data, parse_links
 
 
 __all__ = ['qglue']

--- a/glue_qt/qglue.py
+++ b/glue_qt/qglue.py
@@ -9,7 +9,6 @@ Utility function to load a variety of python objects into glue
 import sys
 from contextlib import contextmanager
 
-from glue.core import BaseData, Data
 from glue.core.parsers import parse_data, parse_links
 
 


### PR DESCRIPTION
Fix imports of parse_data and parse_links in qglue.py - these should not be in a try...except anymore anyway as this was originally related to circular imports which are no longer an issue.