### PR TITLE
Refresh table sorting when data changes

### DIFF
--- a/glue_qt/viewers/table/data_viewer.py
+++ b/glue_qt/viewers/table/data_viewer.py
@@ -153,6 +153,8 @@ class DataTableModel(QtCore.QAbstractTableModel):
         self._update_visible()
         self.data_by_row_and_column.cache_clear()
         self.layoutChanged.emit()
+        self.sort_column = column
+        self.sort_ascending = ascending
 
     def get_filter_mask(self):
         if (self._state.filter is None) or (self._state.filter_att is None):
@@ -403,3 +405,17 @@ class TableViewer(DataViewer):
     @staticmethod
     def update_viewer_state(rec, context):
         return update_table_viewer_state(rec, context)
+
+    def _update_data_numerical(self, *args, **kwargs):
+        """
+        If we change the data in a component and
+        we are sorting on that component, we need to
+        trigger the sorting to happen again. Since it
+        is a little fragile to figure out which component
+        we are currently sorting on, we'll just sort whenever
+        we receive this message.
+        """
+        super()._update_data_numerical(*args, **kwargs)
+        if self.model is not None:
+            if getattr(self.model, 'sort_column', None) is not None:
+                self.model.sort(self.model.sort_column, self.model.sort_ascending)

--- a/glue_qt/viewers/table/tests/test_data_viewer.py
+++ b/glue_qt/viewers/table/tests/test_data_viewer.py
@@ -734,3 +734,45 @@ def test_table_widget_session_filter(tmpdir):
     assert widget2.state.filter_att == d.components[2]
     assert widget2.state.filter == 'cat'
     np.testing.assert_equal(model2.filter_mask, [True, False, True, False, False])
+
+
+def test_table_sorts_after_update_data():
+
+    # Test that a sorted table will resort if the
+    # underlying data components are updated
+    # (which will emit a NumericalDataChangedMessage)
+
+    app = get_qapp()  # noqa
+
+    d = Data(a=[1, 2, 3, 4, 5],
+             b=[3.2, 1.2, 4.5, 3.3, 2.2],
+             c=['e', 'b', 'c', 'a', 'f'], label='test')
+
+    dc = DataCollection([d])
+
+    gapp = GlueApplication(dc)
+
+    viewer = gapp.new_data_viewer(TableViewer)
+    viewer.add_data(d)
+
+    model = viewer.ui.table.model()
+
+    model.sort(1, Qt.AscendingOrder)
+
+    data = {'a': [2, 5, 1, 4, 3],
+            'b': [1.2, 2.2, 3.2, 3.3, 4.5],
+            'c': ['b', 'f', 'e', 'a', 'c']}
+    colors = [None for _ in range(5)]
+
+    check_values_and_color(model, data, colors)
+
+    d.update_components({d.components[2]: [3.2, 1.2, 4.5, 2.5, 3.4]})
+
+    process_events()
+
+    data = {'a': [2, 4, 1, 5, 3],
+            'b': [1.2, 2.5, 3.2, 3.4, 4.5],
+            'c': ['b', 'a', 'e', 'f', 'c']}
+    colors = [None for _ in range(5)]
+
+    check_values_and_color(model, data, colors)


### PR DESCRIPTION
# Pull Request Template

## Description

Currently, if the underlying data in a component changes, the values are refreshed in the Table Viewer but sorting is not maintained. That is, if the Viewer is currently sorted on a column and the values in that column change, the table is no longer sorted. This forces a re-sort if there is a change to the underlying data and adds a test that does not pass without the change.