### PR TITLE
Improve tables for incompatible subsets

### DIFF
--- a/glue_qt/viewers/table/tests/test_data_viewer.py
+++ b/glue_qt/viewers/table/tests/test_data_viewer.py
@@ -482,7 +482,7 @@ def test_table_incompatible_attribute():
     sg1 = dc.new_subset_group('invalid', d1.id['x'] <= 3)
 
     gapp.show()
-    process_events()
+    process_events(0.5)
 
     assert len(viewer.layers) == 2
     assert viewer.layers[0].visible
@@ -491,7 +491,7 @@ def test_table_incompatible_attribute():
     # This subset can be shown in the viewer
     sg2 = dc.new_subset_group('valid', d2.id['a'] == 'a')
 
-    process_events()
+    process_events(0.5)
 
     assert len(viewer.layers) == 3
     assert viewer.layers[0].visible
@@ -504,7 +504,7 @@ def test_table_incompatible_attribute():
     # the invalid subset
     viewer.layers[0].visible = False
 
-    process_events()
+    process_events(0.5)
 
     assert not viewer.layers[0].visible
     assert not viewer.layers[1].visible
@@ -516,7 +516,7 @@ def test_table_incompatible_attribute():
 
     sg3 = dc.new_subset_group('invalid', d1.id['y'] > 6)
 
-    process_events()
+    process_events(0.5)
 
     assert len(viewer.layers) == 4
     assert not viewer.layers[0].visible
@@ -529,7 +529,7 @@ def test_table_incompatible_attribute():
 
     sg1.subset_state = d2.id['b'] == 'b'
 
-    process_events()
+    process_events(0.5)
 
     assert len(viewer.layers) == 4
     assert not viewer.layers[0].visible


### PR DESCRIPTION
# Catch IncompatibleAttributeError for subset-only tables and show newly-valid subsets

## Description

There were a few state problems with tables and incompatible subsets. This fixes the following two issues:

1. A table without the underlying full data layer visible (i.e. just one or more subsets) would generate an uncaught `IncompatibleAttributeError` when any of the visible subsets became invalid (i.e. because they were no longer subsets on the tabular dataset.
2. When a subset was disabled for a table viewer (because it was incompatible), later redefining that same subset on the tabular dataset did not re-enable the subset layer in the viewer, which makes it look as if the subset creation did not work.