### PR TITLE
Don't apply color to existing datasets by default

### DIFF
--- a/glue_qt/app/preferences.ui
+++ b/glue_qt/app/preferences.ui
@@ -199,7 +199,7 @@
           <string/>
          </property>
          <property name="checked">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
When editing one's glue preferences using the dialog, the checkbox to apply the default color to existing datasets is checked by default. This makes it really easy to accidentally change all of the datasets in one's session to the same color (gray if one hasn't modified this setting) when modifying another setting. This PR updates the preferences dialog so that this checkbox is now unchecked by default.