### PR TITLE
Update `ptp` call for numpy 2

### DIFF
--- a/glue_qt/plugins/dendro_viewer/data_viewer.py
+++ b/glue_qt/plugins/dendro_viewer/data_viewer.py
@@ -45,7 +45,7 @@ class DendrogramViewer(MatplotlibDataViewer):
         x, y = self.state._layout.xy
         x, y = x[::3], y[::3]
         xlim = np.array([x.min(), x.max()])
-        xpad = .05 * xlim.ptp()
+        xpad = .05 * np.ptp(xlim)
         xlim[0] -= xpad
         xlim[1] += xpad
 
@@ -56,7 +56,7 @@ class DendrogramViewer(MatplotlibDataViewer):
             ylim[0] /= pad
             ylim[1] *= pad
         else:
-            pad = .05 * ylim.ptp()
+            pad = .05 * np.ptp(ylim)
             ylim[0] -= pad
             ylim[1] += pad
 


### PR DESCRIPTION
In numpy 2, the `ptp` method has been removed from `ndarray` (see the relevant part of the numpy 2 migration guide [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ndarray-and-scalar-methods)). However, `np.ptp` has been retained from 1.x, so this PR updates our method calls to use `np.ptp` for compatibility with both major versions.