### PR TITLE
Pin pytest to <8.3.3 as the test suite currently segfaults with 8.3.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
 qt =
     PyQt5>=5.14
 test =
-    pytest
+    pytest<8.3.3
     pytest-cov
     pytest-faulthandler
     pytest-flake8


### PR DESCRIPTION
The test suite is completely broken with 8.3.3 as it segfaults - the relevant change in pytest is https://github.com/pytest-dev/pytest/pull/12781/