### PR TITLE
Add glue-core to dev-deps and Python 3.13 envs to CI; compatibility with glue 1.22 BaseViewer

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -102,9 +102,9 @@ jobs:
         # PyQt5 / < 6.6 segfaulting under macOS 14 (on arm64) in TestGlueDataDialog or TestLinkEditor
         # Python 3.11.0 failing on Windows in test_image.py on
         # > assert df.find_factory(fname) is df.img_data
-        - linux: py310-test-pyside64-skipexitcode
-        - linux: py311-test-pyside65-skipexitcode
-        - linux: py312-test-pyside67-skipexitcode
+        - linux: py311-test-pyside64-skipexitcode
+        - linux: py312-test-pyside65-skipexitcode
+        - linux: py313-test-pyside67-skipexitcode
         - macos: py310-test-pyside63-skipexitcode
         - macos: py311-test-pyside64-skipexitcode
         - macos: py312-test-pyside67-skipexitcode

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -33,8 +33,6 @@ jobs:
           - libegl1
           - libopenblas-dev
           - libhdf5-dev
-        brew:
-          - enchant
 
       envs: |
         # Standard tests
@@ -56,10 +54,12 @@ jobs:
           coverage: false
         - macos: py311-docs-pyqt64
           coverage: false
+          libraries:
+            brew:
+              - enchant
 
         # Test a few configurations on macOS 13 (Intel, default for py<310) and 14 (Arm)
         - macos: py38-test-pyqt514-all
-        - macos: py39-test-pyqt515
         - macos: py311-test-pyqt65
         - macos: py312-test-pyqt66
           runs-on: macos-13

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,7 +30,7 @@ jobs:
         apt:
           - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
-          - libegl1-mesa
+          - libegl1
           - libopenblas-dev
           - libhdf5-dev
         brew:
@@ -45,6 +45,7 @@ jobs:
         - linux: py310-test-pyqt63-all
         - linux: py311-test-pyqt64
         - linux: py312-test-pyqt65
+        - linux: py312-test-pyqt68
         - linux: py313-test-pyqt67
         - linux: py311-test-pyqt66-all
         - linux: py311-test-pyqt514
@@ -56,23 +57,25 @@ jobs:
         - macos: py311-docs-pyqt64
           coverage: false
 
-        # Test a few configurations on macOS 12 (Intel) and 14 (ARM)
+        # Test a few configurations on macOS 13 (Intel, default for py<310) and 14 (Arm)
         - macos: py38-test-pyqt514-all
+        - macos: py39-test-pyqt515
         - macos: py311-test-pyqt65
-        - macos: py312-test-pyqt67
-        - macos: py313-test-pyqt66
+        - macos: py312-test-pyqt66
+          runs-on: macos-13
+        - macos: py313-test-pyqt68
 
         # Test some configurations on Windows
-        - windows: py39-test-pyqt514
+        - windows: py38-test-pyqt514
         - windows: py310-test-pyqt63
         - windows: py311-test-pyqt65
-        - windows: py312-test-pyqt66
+        - windows: py312-test-pyqt67
 
         # Test against latest developer versions of some packages
         - linux: py311-test-pyqt64-dev
         - linux: py312-test-pyqt515-dev-all
         - linux: py312-test-pyqt67-dev
-        - linux: py313-test-pyqt66-dev-all
+        - linux: py313-test-pyqt68-dev-all
 
   allowed_failures:
     needs: initial_checks
@@ -84,7 +87,7 @@ jobs:
         apt:
           - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
-          - libegl1-mesa
+          - libegl1
           - libopenblas-dev
           - libhdf5-dev
         brew:
@@ -103,14 +106,14 @@ jobs:
         # Python 3.11.0 failing on Windows in test_image.py on
         # > assert df.find_factory(fname) is df.img_data
         - linux: py311-test-pyside64-skipexitcode
-        - linux: py312-test-pyside65-skipexitcode
-        - linux: py313-test-pyside67-skipexitcode
+        - linux: py312-test-pyside66-skipexitcode
+        - linux: py313-test-pyside68-skipexitcode
         - macos: py310-test-pyside63-skipexitcode
         - macos: py311-test-pyside64-skipexitcode
-        - macos: py312-test-pyside67-skipexitcode
+        - macos: py312-test-pyside68-skipexitcode
         - macos: py310-test-pyqt515
         - windows: py310-test-pyside64
-        - windows: py312-test-pyside66
+        - windows: py312-test-pyside67
         - windows: py311-test-pyqt515
 
         # Windows docs build

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -45,6 +45,7 @@ jobs:
         - linux: py310-test-pyqt63-all
         - linux: py311-test-pyqt64
         - linux: py312-test-pyqt65
+        - linux: py313-test-pyqt67
         - linux: py311-test-pyqt66-all
         - linux: py311-test-pyqt514
         - linux: py311-test-pyqt515-lts-all
@@ -57,20 +58,21 @@ jobs:
 
         # Test a few configurations on macOS 12 (Intel) and 14 (ARM)
         - macos: py38-test-pyqt514-all
-        - macos: py311-test-pyqt66
+        - macos: py311-test-pyqt65
         - macos: py312-test-pyqt67
+        - macos: py313-test-pyqt66
 
         # Test some configurations on Windows
-        - windows: py38-test-pyqt514
+        - windows: py39-test-pyqt514
         - windows: py310-test-pyqt63
         - windows: py311-test-pyqt65
         - windows: py312-test-pyqt66
 
         # Test against latest developer versions of some packages
-        - linux: py310-test-pyqt515-dev-all
         - linux: py311-test-pyqt64-dev
-        - linux: py312-test-pyqt515-dev
-        - linux: py312-test-pyqt67-dev-all
+        - linux: py312-test-pyqt515-dev-all
+        - linux: py312-test-pyqt67-dev
+        - linux: py313-test-pyqt66-dev-all
 
   allowed_failures:
     needs: initial_checks

--- a/glue_qt/viewers/common/data_viewer.py
+++ b/glue_qt/viewers/common/data_viewer.py
@@ -123,6 +123,10 @@ class DataViewer(Viewer, BaseQtViewerWidget,
     def warn(self, message, *args, **kwargs):
         return warn(message, *args, **kwargs)
 
+    def close(self, warn=True):
+        # Override NotImplemented BaseViewer.close() added in glue#2520 (1.22)
+        BaseQtViewerWidget.close(self, warn=warn)
+
     def _close_nowarn(self):
         return self.close(warn=False)
 

--- a/glue_qt/viewers/image/tests/test_python_export.py
+++ b/glue_qt/viewers/image/tests/test_python_export.py
@@ -1,7 +1,8 @@
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
-from astropy.utils import NumpyRNGContext
+import astropy
+from astropy.utils import minversion, NumpyRNGContext
 from astropy.wcs import WCS
 
 from glue.core import Data, DataCollection
@@ -9,6 +10,8 @@ from glue.core.coordinates import AffineCoordinates
 from glue_qt.app.application import GlueApplication
 from glue_qt.viewers.image import ImageViewer
 from glue_qt.viewers.matplotlib.tests.test_python_export import BaseTestExportPython
+
+ASTROPY_GE_7 = minversion(astropy, '7.0')
 
 
 class TestExportPython(BaseTestExportPython):
@@ -51,12 +54,16 @@ class TestExportPython(BaseTestExportPython):
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_simple(self, tmpdir, coords):
         self.viewer_load(coords)
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_simple_legend(self, tmpdir, coords):
         self.viewer_load(coords)
         self.viewer.state.show_legend = True
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
@@ -79,6 +86,8 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.layers[0].stretch = 'sqrt'
         self.viewer.state.layers[0].contrast = 0.9
         self.viewer.state.layers[0].bias = 0.6
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
@@ -95,12 +104,16 @@ class TestExportPython(BaseTestExportPython):
     def test_aspect(self, tmpdir, coords):
         self.viewer_load(coords)
         self.viewer.state.aspect = 'auto'
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_subset(self, tmpdir, coords):
         self.viewer_load(coords)
         self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
@@ -109,6 +122,8 @@ class TestExportPython(BaseTestExportPython):
         self.data_collection.new_subset_group('mysubset',
                                               self.viewer.state.reference_data.id['cube'] > 0.5)
         self.viewer.state.legend.visible = True
+        if ASTROPY_GE_7 and coords == 'affine':
+            pytest.xfail('Astropy 7 issue with axis label rendering')
         self.assert_same(tmpdir, tol=0.15)  # transparency and such
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])

--- a/glue_qt/viewers/profile/tests/test_data_viewer.py
+++ b/glue_qt/viewers/profile/tests/test_data_viewer.py
@@ -498,8 +498,10 @@ def test_unit_conversion_limits():
 
     assert viewer.state.x_min == 3.0
     assert viewer.state.x_max == 3.0
-    assert viewer.state.y_min == 0.
-    assert viewer.state.y_max == 1.
+
+    # Limits for constant data == 3.0; this was broken up to glue-core 1.21.1 (glue-viz/glue#2513)
+    assert viewer.state.y_min in (2.7, 0.0)
+    assert viewer.state.y_max in (3.3, 1.0)
 
     # Explicitly set unit on y axis to enable unit conversion
     viewer.state.y_display_unit = 'Jy'

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering :: Visualization
     License :: OSI Approved :: BSD License
 description = Multidimensional data visualization across files

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,11 @@ deps =
     pyside67: PySide6==6.7.*
     pyside68: PySide6==6.8.*
     dev: numpy>=0.0.dev0
+    dev: scipy>=0.0.dev0
     dev: astropy>=0.0.dev0
     dev: git+https://github.com/glue-viz/glue
+    # Fix from https://github.com/pyenchant/pyenchant/pull/302 to find newer Homebrew installations
+    docs: pyenchant>=3.3.0rc1
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
     # Pin numpy-lts until permanent solution for #2353/#2428

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt66,pyqt67,pyqt65,pyqt63,pyside66,pyside67}-all-{dev,legacy}
+    py{38,39,310,311,312,313}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-all-{dev,legacy}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -34,6 +34,8 @@ deps =
     pyqt66: PyQt6==6.6.*
     pyqt67: PyQt6-Qt6==6.7.*
     pyqt67: PyQt6==6.7.*
+    pyqt68: PyQt6-Qt6==6.8.*
+    pyqt68: PyQt6==6.8.*
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
     pyside63: PySide6==6.3.*
@@ -41,6 +43,7 @@ deps =
     pyside65: PySide6==6.5.*
     pyside66: PySide6==6.6.*
     pyside67: PySide6==6.7.*
+    pyside68: PySide6==6.8.*
     dev: numpy>=0.0.dev0
     dev: astropy>=0.0.dev0
     dev: git+https://github.com/glue-viz/glue

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ passenv =
 # Set to 1 to get more debug information from PyQt
 setenv =
     test: QT_DEBUG_PLUGINS = 0
+    dev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 whitelist_externals =
     find
     rm

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt66,pyqt67,pyqt65,pyqt63,pyside66,pyside67}-all-{dev,legacy}
+    py{38,39,310,311,312,313}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt66,pyqt67,pyqt65,pyqt63,pyside66,pyside67}-all-{dev,legacy}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -40,8 +40,9 @@ deps =
     pyside65: PySide6==6.5.*
     pyside66: PySide6==6.6.*
     pyside67: PySide6==6.7.*
-    dev: git+https://github.com/numpy/numpy
-    dev: git+https://github.com/astropy/astropy
+    dev: numpy>=0.0.dev0
+    dev: astropy>=0.0.dev0
+    dev: git+https://github.com/glue-viz/glue
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
     # Pin numpy-lts until permanent solution for #2353/#2428


### PR DESCRIPTION
## Description
Also switching `dev: numpy` and `dev: astropy` to use nightly wheels.
Updating the minimum Python version for `dev` as required by Astropy 7.x (note: [conflicting jobs](https://github.com/glue-viz/glue-qt/actions/runs/11058148689/job/30723576762#step:10:70) would no longer fail with `astropy>=0.0.dev0`, but silently downgrade to 6.1.x!).

Will (hopefully) fix #23