### PR TITLE
Provide int to self._play_timer.setInterval

### DIFF
--- a/glue_qt/viewers/common/data_slice_widget.py
+++ b/glue_qt/viewers/common/data_slice_widget.py
@@ -160,7 +160,7 @@ class SliceWidget(QtWidgets.QWidget):
             self._play_timer.stop()
         else:
             self._play_timer.start()
-            self._play_timer.setInterval(500 / abs(self._play_speed))
+            self._play_timer.setInterval(round(500 / abs(self._play_speed)))
 
     def _play_slice(self):
         if self._play_speed > 0:


### PR DESCRIPTION
## Description

I was trying to change the speed of the movie playback and saw this error:

```
TypeError: setInterval(self, msec: int): argument 1 has unexpected type 'float'
Traceback (most recent call last):
  File "/home/nabil/Git/glue/glue/utils/misc.py", line 55, in result
    return func(*args, **kwargs)
  File "/home/nabil/Git/glue-qt/glue_qt/viewers/common/data_slice_widget.py", line 163, in _adjust_play
    self._play_timer.setInterval(500 / abs(self._play_speed))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I just now force this to be an int with the division. 