### PR TITLE
possible docs fix

### DIFF
--- a/doc/customizing_guide/viewer.rst
+++ b/doc/customizing_guide/viewer.rst
@@ -149,7 +149,7 @@ which should be used as follows::
 
         def __init__(self, *args, **kwargs):
             super(TutorialViewerState).__init__(*args, **kwargs)
-            MyExampleState.linestyle.set_choices(['solid', 'dashed', 'dotted'])
+            self.linestyle.set_choices(['solid', 'dashed', 'dotted'])
 
 This then makes it so that the ``linestyle`` property knows about what valid
 values are, and this will come in useful when developing for example Qt widgets


### PR DESCRIPTION
## Description

In [the custom viewer docs](https://docs.glueviz.org/en/stable/customizing_guide/viewer.html), there's a reference to a variable that's never defined. It looks like a holdover/typo. I revised the line with my best-guess at what I think belongs there, correct me if I'm wrong.