### PR TITLE
Remove graph edge when a link between datasets is completely removed

### DIFF
--- a/glue_qt/dialogs/link_editor/link_editor.py
+++ b/glue_qt/dialogs/link_editor/link_editor.py
@@ -155,6 +155,7 @@ class LinkEditorWidget(QtWidgets.QWidget):
             self._ui.combos2_header.hide()
             for widget in self.att_combos1 + self.att_names1 + self.att_combos2 + self.att_names2:
                 widget.hide()
+            self._ui.graph_widget.set_links(self.state.links)
             return
 
         self._ui.button_remove_link.setEnabled(True)


### PR DESCRIPTION
Today while using glue, Alyssa and I noticed that when all of the links between two datasets are removed in the link editor, the edge is not removed on the graph (note that it won't appear the next time that the link editor is opened, but it persists in the current window). See the video below:

https://github.com/user-attachments/assets/7d596a63-3f29-438c-99f4-8b0773c10cc5

With this PR, the link is removed in the current link editing view:

https://github.com/user-attachments/assets/4e79be34-654e-4ae7-b0ce-00ede72ac2cc

