### PR TITLE
Generalize slice widget to support 3D viewers

### DIFF
--- a/glue_qt/viewers/common/slice_widget.py
+++ b/glue_qt/viewers/common/slice_widget.py
@@ -21,6 +21,8 @@ class MultiSliceWidgetHelper(object):
 
         self.viewer_state.add_callback('x_att', self.sync_sliders_from_state)
         self.viewer_state.add_callback('y_att', self.sync_sliders_from_state)
+        if hasattr(self.viewer_state, 'z_att'):
+            self.viewer_state.add_callback('z_att', self.sync_sliders_from_state)
         self.viewer_state.add_callback('slices', self.sync_sliders_from_state)
         self.viewer_state.add_callback('reference_data', self.sync_sliders_from_state)
 
@@ -29,6 +31,7 @@ class MultiSliceWidgetHelper(object):
         self._reference_data = None
         self._x_att = None
         self._y_att = None
+        self._z_att = None
 
         self.sync_sliders_from_state()
 
@@ -60,27 +63,36 @@ class MultiSliceWidgetHelper(object):
     @avoid_circular
     def sync_sliders_from_state(self, *args):
 
-        if self.data is None or self.viewer_state.x_att is None or self.viewer_state.y_att is None:
+        if self.data is None or \
+           self.viewer_state.x_att is None or \
+           self.viewer_state.y_att is None or \
+           (hasattr(self.viewer_state, "z_att") and self.viewer_state.z_att is None):
             return
 
-        if self.viewer_state.x_att is self.viewer_state.y_att:
+        if any((self.viewer_state.x_att is self.viewer_state.y_att,
+                self.viewer_state.x_att is getattr(self.viewer_state, "z_att", None),
+                self.viewer_state.y_att is getattr(self.viewer_state, "z_att", None))):
             return
 
         # Update sliders if needed
 
         if (self.viewer_state.reference_data is not self._reference_data or
-                self.viewer_state.x_att is not self._x_att or
-                self.viewer_state.y_att is not self._y_att):
+            self.viewer_state.x_att is not self._x_att or
+            self.viewer_state.y_att is not self._y_att or
+            (hasattr(self.viewer_state, "z_att") and self.viewer_state.z_att is not self._z_att)):
 
             self._reference_data = self.viewer_state.reference_data
             self._x_att = self.viewer_state.x_att
             self._y_att = self.viewer_state.y_att
+            self._z_att = getattr(self.viewer_state, "z_att", None)
 
             self._clear()
 
             for i in range(self.data.ndim):
 
-                if i == self.viewer_state.x_att.axis or i == self.viewer_state.y_att.axis:
+                if i == self.viewer_state.x_att.axis or \
+                   i == self.viewer_state.y_att.axis or \
+                   (hasattr(self.viewer_state, "z_att") and i == self.viewer_state.z_att.axis):
                     self._sliders.append(None)
                     continue
 

--- a/glue_qt/viewers/image/options_widget.py
+++ b/glue_qt/viewers/image/options_widget.py
@@ -4,7 +4,7 @@ from qtpy import QtWidgets
 
 from echo.qt import autoconnect_callbacks_to_qt
 from glue_qt.utils import load_ui, fix_tab_widget_fontsize
-from glue_qt.viewers.image.slice_widget import MultiSliceWidgetHelper
+from glue_qt.viewers.common.slice_widget import MultiSliceWidgetHelper
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
 
 __all__ = ['ImageOptionsWidget']


### PR DESCRIPTION
This PR updates the slice widget viewer to be able to support a viewer with three dimensions (i.e. it also has a `z_att`). The motivation here is https://github.com/glue-viz/glue-vispy-viewers/pull/399. Since this generalizes the widget helper beyond just the image viewer, this PR also moves it to `viewers.common`.