### PR TITLE
Create colormap widget for reversing colormaps

### DIFF
--- a/glue_qt/utils/colors.py
+++ b/glue_qt/utils/colors.py
@@ -227,41 +227,33 @@ class QColormapWidget(QtWidgets.QWidget):
         super(QColormapWidget, self).__init__(*args, **kwargs)
         layout = QtWidgets.QHBoxLayout()
         self.cmap_combo = QColormapCombo()
-        self.cmap_checkbox = QtWidgets.QCheckBox(text="Reverse")
-        self.cmap_combo.setMaximumWidth(100)
+        self.cmap_button = QtWidgets.QPushButton(text="⇄")
+        self.cmap_button.setCheckable(True)
+        self.cmap_button.setMaximumWidth(25)
+        self.cmap_button.adjustSize()
         layout.addWidget(self.cmap_combo)
-        layout.addWidget(self.cmap_checkbox)
+        layout.addWidget(self.cmap_button)
         self.setLayout(layout)
 
-        self.cmap_checkbox.toggled.connect(self._update_from_checkbox)
+        self.cmap_button.toggled.connect(self._update_from_checkbox)
         self.cmap_combo.currentIndexChanged.connect(self._update_from_combo)
 
     def value(self):
-        return self.itemData(self.cmap_combo.currentIndex(), reverse=self.cmap_checkbox.isChecked()).data
+        return self.itemData(self.cmap_combo.currentIndex(), reverse=self.cmap_button.isChecked()).data
 
     def isChecked(self):
-        return self.cmap_checkbox.isChecked()
+        return self.cmap_button.isChecked()
 
     def _update_from_checkbox(self, value):
-        print("Update from checkbox")
-        print(self.value().name)
         self.changed.emit()
-        print("======")
 
     def _update_from_combo(self, index):
-        print("Update from combo")
-        print(self.value().name)
         self.cmap_combo.setCurrentIndex(index)
-        print("*************")
 
     def set(self, index, reverse):
-        print("SET")
-        with QtCore.QSignalBlocker(self.cmap_combo), QtCore.QSignalBlocker(self.cmap_checkbox):
+        with QtCore.QSignalBlocker(self.cmap_combo), QtCore.QSignalBlocker(self.cmap_button):
             self.cmap_combo.setCurrentIndex(index)
-            self.cmap_checkbox.setChecked(reverse)
-            print("Exiting signal blocker")
-        print(self.value().name)
-        print("XXXXXXXX")
+            self.cmap_button.setChecked(reverse)
         self.changed.emit()
 
     def count(self):
@@ -272,9 +264,6 @@ class QColormapWidget(QtWidgets.QWidget):
         data = wrapper.data
         if reverse:
             data = data.reversed()
-        print("itemData")
-        print(data.name)
-        print("--------")
         return UserDataWrapper(data=data)
 
 
@@ -311,12 +300,9 @@ def connect_color_combo(client, prop, widget):
                 idx, reverse = -1, False
             else:
                 raise
-        print("Found data", idx, reverse)
         widget.set(idx, reverse)
 
     def update_prop():
-        print("Update prop")
-        print(widget.value().name)
         setattr(client, prop, widget.value())
 
     add_callback(client, prop, update_widget)

--- a/glue_qt/utils/colors.py
+++ b/glue_qt/utils/colors.py
@@ -223,12 +223,32 @@ class QColormapWidget(QtWidgets.QWidget):
 
     def __init__(self, *args, **kwargs):
         super(QColormapWidget, self).__init__(*args, **kwargs)
-        layout = QtWidgets.QHBoxLayout(parent=self)
-        self.cmap_combo = QColormapCombo(parent=self)
-        self.cmap_checkbox = QtWidgets.QCheckBox(parent=self)
+        layout = QtWidgets.QHBoxLayout()
+        self.cmap_combo = QColormapCombo()
+        self.cmap_checkbox = QtWidgets.QCheckBox(text="Reverse")
+        self.cmap_combo.setMaximumWidth(100)
         layout.addWidget(self.cmap_combo)
         layout.addWidget(self.cmap_checkbox)
         self.setLayout(layout)
+
+        self.cmap_checkbox.toggled.connect(self._update_from_checkbox)
+        self.currentIndexChanged = self.cmap_combo.currentIndexChanged
+
+    def _update_from_checkbox(self, _value):
+        self.currentIndexChanged.emit(self.cmap_combo.currentIndex())
+
+    def setCurrentIndex(self, index):
+        self.cmap_combo.setCurrentIndex(index)
+
+    def count(self):
+        return self.cmap_combo.count()
+
+    def itemData(self, index):
+        wrapper = self.cmap_combo.itemData(index)
+        data = wrapper.data
+        if self.cmap_checkbox.isChecked():
+            data = data.reversed()
+        return UserDataWrapper(data=data)
 
 
 if __name__ == "__main__":

--- a/glue_qt/utils/colors.py
+++ b/glue_qt/utils/colors.py
@@ -227,16 +227,17 @@ class QColormapWidget(QtWidgets.QWidget):
         super(QColormapWidget, self).__init__(*args, **kwargs)
         layout = QtWidgets.QHBoxLayout()
         self.cmap_combo = QColormapCombo()
+        self.cmap_combo.setMinimumWidth(100)
         self.cmap_button = QtWidgets.QPushButton(text="⇄")
         self.cmap_button.setCheckable(True)
         self.cmap_button.setMaximumWidth(25)
-        self.cmap_button.adjustSize()
-        layout.addWidget(self.cmap_combo)
+        layout.addWidget(self.cmap_combo, stretch=1)
         layout.addWidget(self.cmap_button)
+        layout.setSpacing(3)
         self.setLayout(layout)
 
-        self.cmap_button.toggled.connect(self._update_from_checkbox)
-        self.cmap_combo.currentIndexChanged.connect(self._update_from_combo)
+        self.cmap_button.toggled.connect(self._update_from_widget)
+        self.cmap_combo.currentIndexChanged.connect(self._update_from_widget)
 
     def value(self):
         return self.itemData(self.cmap_combo.currentIndex(), reverse=self.cmap_button.isChecked()).data
@@ -244,11 +245,8 @@ class QColormapWidget(QtWidgets.QWidget):
     def isChecked(self):
         return self.cmap_button.isChecked()
 
-    def _update_from_checkbox(self, value):
+    def _update_from_widget(self, value):
         self.changed.emit()
-
-    def _update_from_combo(self, index):
-        self.cmap_combo.setCurrentIndex(index)
 
     def set(self, index, reverse):
         with QtCore.QSignalBlocker(self.cmap_combo), QtCore.QSignalBlocker(self.cmap_button):

--- a/glue_qt/utils/colors.py
+++ b/glue_qt/utils/colors.py
@@ -237,7 +237,7 @@ class QColormapWidget(QtWidgets.QWidget):
         self.cmap_combo.currentIndexChanged.connect(self._update_from_combo)
 
     def value(self):
-        return self.itemData(self.cmap_combo.currentIndex()).data
+        return self.itemData(self.cmap_combo.currentIndex(), reverse=self.cmap_checkbox.isChecked()).data
 
     def isChecked(self):
         return self.cmap_checkbox.isChecked()
@@ -267,10 +267,10 @@ class QColormapWidget(QtWidgets.QWidget):
     def count(self):
         return self.cmap_combo.count()
 
-    def itemData(self, index):
+    def itemData(self, index, reverse=False):
         wrapper = self.cmap_combo.itemData(index)
         data = wrapper.data
-        if self.cmap_checkbox.isChecked():
+        if reverse:
             data = data.reversed()
         print("itemData")
         print(data.name)
@@ -286,22 +286,17 @@ def _find_cmap_combo_data(widget, value):
     """
     # Here we check that the result is True, because some classes may overload
     # == and return other kinds of objects whether true or false.
-    checked = widget.isChecked()
     for idx in range(widget.count()):
         if (item_data := widget.itemData(idx)) is not None:
             if isinstance(item_data, UserDataWrapper):
                 data = item_data.data
-                if data is value or (data == value) is True:
-                    return idx, checked 
-                data = data.reversed()
-                if data is value or (data == value) is True:
-                    return idx, not checked
             else:
-                if item_data is value or (item_data == value) is True:
-                    return idx, checked 
-                item_data = item_data.reversed()
-                if item_data is value or (item_data == value) is True:
-                    return idx, not checked
+                data = item_data
+            if data is value or (data == value) is True:
+                return idx, False 
+            data = data.reversed()
+            if data is value or (data == value) is True:
+                return idx, True
     else:
         raise ValueError("%s not found in combo box" % (value,))
 
@@ -321,6 +316,7 @@ def connect_color_combo(client, prop, widget):
 
     def update_prop():
         print("Update prop")
+        print(widget.value().name)
         setattr(client, prop, widget.value())
 
     add_callback(client, prop, update_widget)

--- a/glue_qt/utils/colors.py
+++ b/glue_qt/utils/colors.py
@@ -219,6 +219,18 @@ class QColormapCombo(QtWidgets.QComboBox):
         self._update_icons()
 
 
+class QColormapWidget(QtWidgets.QWidget):
+
+    def __init__(self, *args, **kwargs):
+        super(QColormapWidget, self).__init__(*args, **kwargs)
+        layout = QtWidgets.QHBoxLayout(parent=self)
+        self.cmap_combo = QColormapCombo(parent=self)
+        self.cmap_checkbox = QtWidgets.QCheckBox(parent=self)
+        layout.addWidget(self.cmap_combo)
+        layout.addWidget(self.cmap_checkbox)
+        self.setLayout(layout)
+
+
 if __name__ == "__main__":
 
     from glue_qt.utils import get_qapp

--- a/glue_qt/viewers/image/layer_style_editor.py
+++ b/glue_qt/viewers/image/layer_style_editor.py
@@ -30,7 +30,7 @@ class ImageLayerStyleEditor(QtWidgets.QWidget):
     def _update_color_mode(self, color_mode):
         if color_mode == 'Colormaps':
             self.ui.color_color.hide()
-            self.ui.combodata_cmap.show()
+            self.ui.cmap_cmap.show()
         else:
             self.ui.color_color.show()
-            self.ui.combodata_cmap.hide()
+            self.ui.cmap_cmap.hide()

--- a/glue_qt/viewers/image/layer_style_editor.ui
+++ b/glue_qt/viewers/image/layer_style_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>197</height>
+    <height>204</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -43,7 +43,6 @@
     <widget class="QLabel" name="label_3">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -59,7 +58,6 @@
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -92,20 +90,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QColormapCombo" name="combodata_cmap">
-         <property name="minimumSize">
-          <size>
-           <width>80</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-         <property name="frame">
-          <bool>false</bool>
-         </property>
-        </widget>
+        <widget class="QColormapWidget" name="cmap_cmap" native="true"/>
        </item>
        <item>
         <widget class="QColorBox" name="color_color">
@@ -249,7 +234,6 @@
     <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -265,7 +249,6 @@
     <widget class="QLabel" name="label">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -299,9 +282,10 @@
    <header>glue_qt.utils.colors</header>
   </customwidget>
   <customwidget>
-   <class>QColormapCombo</class>
-   <extends>QComboBox</extends>
+   <class>QColormapWidget</class>
+   <extends>QWidget</extends>
    <header>glue_qt.utils.colors</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/glue_qt/viewers/scatter/layer_style_editor.py
+++ b/glue_qt/viewers/scatter/layer_style_editor.py
@@ -216,7 +216,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.valuetext_cmap_vmin.hide()
             self.ui.valuetext_cmap_vmax.hide()
             self.ui.button_flip_cmap.hide()
-            self.ui.combodata_cmap.hide()
+            self.ui.cmap_cmap.hide()
             self.ui.label_colormap.hide()
             self.ui.color_color.show()
         else:
@@ -226,7 +226,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.valuetext_cmap_vmin.show()
             self.ui.valuetext_cmap_vmax.show()
             self.ui.button_flip_cmap.show()
-            self.ui.combodata_cmap.show()
+            self.ui.cmap_cmap.show()
             self.ui.label_colormap.show()
             self.ui.color_color.hide()
 

--- a/glue_qt/viewers/scatter/layer_style_editor.ui
+++ b/glue_qt/viewers/scatter/layer_style_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>330</width>
-    <height>322</height>
+    <height>325</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,7 +71,6 @@
         <widget class="QLabel" name="label_7">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -159,7 +158,6 @@
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -175,7 +173,6 @@
         <widget class="QLabel" name="label_cmap_limits">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -191,7 +188,6 @@
         <widget class="QLabel" name="label_colormap">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -207,7 +203,6 @@
         <widget class="QLabel" name="label_cmap_attribute">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -221,6 +216,12 @@
        </item>
        <item row="4" column="1" colspan="3">
         <widget class="QColormapWidget" name="cmap_cmap" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
         </widget>
        </item>
       </layout>
@@ -265,7 +266,6 @@
         <widget class="QLabel" name="label">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -281,7 +281,6 @@
         <widget class="QLabel" name="label_size_limits">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -310,7 +309,6 @@
         <widget class="QLabel" name="label_dpi">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -329,7 +327,6 @@
         <widget class="QLabel" name="label_size_attribute">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -348,7 +345,6 @@
         <widget class="QLabel" name="label_size_scaling">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -367,7 +363,6 @@
         <widget class="QLabel" name="label_size_mode">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -444,7 +439,6 @@
         <widget class="QLabel" name="label_14">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -477,7 +471,6 @@
         <widget class="QLabel" name="label_stretch">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -513,7 +506,6 @@
         <widget class="QLabel" name="label_contrast">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -536,7 +528,6 @@
         <widget class="QLabel" name="label_fill">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -604,7 +595,6 @@
         <widget class="QLabel" name="label_8">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -636,7 +626,6 @@
         <widget class="QLabel" name="label_9">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -652,7 +641,6 @@
         <widget class="QLabel" name="label_2">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -754,7 +742,6 @@
         <widget class="QLabel" name="label_6">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -767,7 +754,6 @@
         <widget class="QLabel" name="label_5">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -832,7 +818,6 @@
         <widget class="QLabel" name="label_3">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -855,7 +840,6 @@
         <widget class="QLabel" name="label_vector_x">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -887,7 +871,6 @@
         <widget class="QLabel" name="label_12">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -906,7 +889,6 @@
         <widget class="QLabel" name="label_4">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -929,7 +911,6 @@
         <widget class="QLabel" name="label_vector_y">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -945,7 +926,6 @@
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -994,7 +974,6 @@
         <widget class="QLabel" name="label_13">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>

--- a/glue_qt/viewers/scatter/layer_style_editor.ui
+++ b/glue_qt/viewers/scatter/layer_style_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>330</width>
-    <height>296</height>
+    <height>322</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -220,17 +220,7 @@
         </widget>
        </item>
        <item row="4" column="1" colspan="3">
-        <widget class="QColormapCombo" name="combodata_cmap">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
+        <widget class="QColormapWidget" name="combodata_cmap" native="true"/>
        </item>
       </layout>
      </widget>
@@ -1044,9 +1034,10 @@
    <header>glue_qt.utils.colors</header>
   </customwidget>
   <customwidget>
-   <class>QColormapCombo</class>
-   <extends>QComboBox</extends>
+   <class>QColormapWidget</class>
+   <extends>QWidget</extends>
    <header>glue_qt.utils.colors</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/glue_qt/viewers/scatter/layer_style_editor.ui
+++ b/glue_qt/viewers/scatter/layer_style_editor.ui
@@ -221,12 +221,6 @@
        </item>
        <item row="4" column="1" colspan="3">
         <widget class="QColormapWidget" name="cmap_cmap" native="true">
-         <property name="maximumSize">
-          <size>
-           <width>227</width>
-           <height>16777215</height>
-          </size>
-         </property>
         </widget>
        </item>
       </layout>

--- a/glue_qt/viewers/scatter/layer_style_editor.ui
+++ b/glue_qt/viewers/scatter/layer_style_editor.ui
@@ -220,7 +220,14 @@
         </widget>
        </item>
        <item row="4" column="1" colspan="3">
-        <widget class="QColormapWidget" name="combodata_cmap" native="true"/>
+        <widget class="QColormapWidget" name="cmap_cmap" native="true">
+         <property name="maximumSize">
+          <size>
+           <width>227</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
This PR adds a new colormap control widget, which consists of a combobox + a checkable button. The combobox is populated with the colormaps in the config, together with a checkable button that allows reversing the colormap. This allows us a simple way to manage reverse colormaps without needing to handle it inside of a layer state. Note that we can get away with doing this because layer state colormaps aren't a selection callback property (as the dropdown is populated via the config instead).

Because of the two widget <--> one state item setup here, this requires its own custom echo handler (or at least I couldn't see a way around that). Also, any viewer that wants to use this will need to update its UI file. This PR makes the updates to the Qt scatter and image viewers.