### PR TITLE
Don't show a slider for a "flat" dimension

### DIFF
--- a/glue_qt/viewers/common/slice_widget.py
+++ b/glue_qt/viewers/common/slice_widget.py
@@ -114,14 +114,17 @@ class MultiSliceWidgetHelper(object):
                     world_warning = False
                     world_label = self.data.pixel_component_ids[i].label
 
-                slider = SliceWidget(world_label,
-                                     hi=self.data.shape[i] - 1, world=world,
-                                     world_unit=world_unit, world_warning=world_warning)
+                if self.data.shape[i] > 1:
+                    slider = SliceWidget(world_label,
+                                         hi=self.data.shape[i] - 1, world=world,
+                                         world_unit=world_unit, world_warning=world_warning)
 
-                self.slider_state = slider.state
-                self.slider_state.add_callback('slice_center', self.sync_state_from_sliders)
-                self._sliders.append(slider)
-                self.layout.addWidget(slider)
+                    self.slider_state = slider.state
+                    self.slider_state.add_callback('slice_center', self.sync_state_from_sliders)
+                    self._sliders.append(slider)
+                    self.layout.addWidget(slider)
+                else:
+                    self._sliders.append(None)
 
         for i in range(self.data.ndim):
             if self._sliders[i] is not None:


### PR DESCRIPTION
This is perhaps a bit of an edge case, but currently there's a "flat" dimension in a dataset (i.e., the shape at that index is 1) that's not the x/y (and z if you're in the volume viewer) attribute, then you'll get a slice widget with no slider (since then `high=0` and the usual set of buttons that then don't do anything. See the screenshot below.

This looks/feels kinda janky (I thought the slider was broken until I realized that the dataset I was looking at was "flat"), so what I propose here is that we just put in `None` in the list of sliders for that dimension - i.e. don't show a slider.

A quick sample dataset if one wants to reproduce this (run in the glue terminal):

```python
from glue.core import Data
import numpy as np

x = np.arange(24).reshape((6, 4, 1))
d = Data(x=x, label="Flat Cube")
dc.append(d)
```

What this currently looks like:
<img width="288" height="103" alt="Screenshot 2025-08-21 at 3 42 52 PM" src="https://github.com/user-attachments/assets/73f2f551-e28c-41b5-9a2e-900b1d73bf6c" />
