### PR TITLE
Allow terminal to move between tabs

### DIFF
--- a/glue_qt/app/application.py
+++ b/glue_qt/app/application.py
@@ -322,7 +322,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._update_viewer_in_focus()
 
     def _on_tab_change(self, *args):
-        self._button_ipython.setChecked(False)
+        index = args[0]
+        check = index == self._terminal_tab() and self._terminal is not None and self._terminal.isVisible()
+        self._button_ipython.setChecked(check)
         self._update_viewer_in_focus(args)
 
     def _update_viewer_in_focus(self, *args):

--- a/glue_qt/app/application.py
+++ b/glue_qt/app/application.py
@@ -26,6 +26,7 @@ from glue_qt.app.edit_subset_mode_toolbar import EditSubsetModeToolBar
 from glue_qt.app.mdi_area import GlueMdiArea
 from glue_qt.app.layer_tree_widget import PlotAction, LayerTreeWidget
 from glue_qt.app.preferences import PreferencesDialog
+from glue_qt.utils.helpers import is_descendant_of
 from glue_qt.viewers.common.data_viewer import DataViewer
 from glue_qt.viewers.scatter import ScatterViewer
 from glue_qt.viewers.image import ImageViewer
@@ -320,6 +321,10 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self.new_tab()
         self._update_viewer_in_focus()
 
+    def _on_tab_change(self, *args):
+        self._button_ipython.setChecked(False)
+        self._update_viewer_in_focus(args)
+
     def _update_viewer_in_focus(self, *args):
 
         if not hasattr(self, '_viewer_in_focus'):
@@ -584,6 +589,11 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
         w = self.tab_widget.widget(index)
 
+        terminal_tab = self._terminal_tab()
+        if index == terminal_tab:
+            page = self.tab(index)
+            page.removeSubWindow(self._terminal)
+
         if len(w.subWindowList()) > 0:
 
             if warn and not os.environ.get('GLUE_TESTING'):
@@ -729,7 +739,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._layer_widget.setup(self._data)
 
         self.tab_widget.tabCloseRequested.connect(self.close_tab)
-        self.tab_widget.currentChanged.connect(self._update_viewer_in_focus)
+        self.tab_widget.currentChanged.connect(self._on_tab_change)
 
     def _create_menu(self):
         mbar = self.menuBar()
@@ -1165,15 +1175,31 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             self._terminal.closed.connect(self._on_terminal_close)
             self._hide_terminal()
 
+    def _move_terminal_to_tab(self, tab):
+        page = self.tab(tab)
+        page.addSubWindow(self._terminal)
+
+    def _terminal_tab(self):
+        for tab in range(self.tab_count):
+            page = self.tab(tab)
+            if is_descendant_of(self._terminal, page):
+                return tab
+        return None
+
     def _toggle_terminal(self):
         if self._terminal is None:
             self._create_terminal()
+
         if self._terminal.isVisible():
             self._hide_terminal()
             if self._terminal.isVisible():
                 warnings.warn("An unexpected error occurred while "
                               "trying to hide the terminal")
         else:
+            terminal_tab = self._terminal_tab()
+            current_tab_index = self.get_tab_index(self.current_tab)
+            if terminal_tab != current_tab_index:
+                self._move_terminal_to_tab(current_tab_index)
             self._show_terminal()
             if not self._terminal.isVisible():
                 warnings.warn("An unexpected error occurred while "

--- a/glue_qt/app/application.py
+++ b/glue_qt/app/application.py
@@ -323,7 +323,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
     def _on_tab_change(self, *args):
         index = args[0]
-        check = index == self._terminal_tab() and self._terminal is not None and self._terminal.isVisible()
+        check = index == self.terminal_tab and self._terminal is not None and self._terminal.isVisible()
         self._button_ipython.setChecked(check)
         self._update_viewer_in_focus(args)
 
@@ -591,8 +591,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
         w = self.tab_widget.widget(index)
 
-        terminal_tab = self._terminal_tab()
-        if index == terminal_tab:
+        if index == self.terminal_tab:
             page = self.tab(index)
             page.removeSubWindow(self._terminal)
 
@@ -1181,7 +1180,8 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         page = self.tab(tab)
         page.addSubWindow(self._terminal)
 
-    def _terminal_tab(self):
+    @property
+    def terminal_tab(self):
         for tab in range(self.tab_count):
             page = self.tab(tab)
             if is_descendant_of(self._terminal, page):
@@ -1198,9 +1198,8 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                 warnings.warn("An unexpected error occurred while "
                               "trying to hide the terminal")
         else:
-            terminal_tab = self._terminal_tab()
             current_tab_index = self.get_tab_index(self.current_tab)
-            if terminal_tab != current_tab_index:
+            if self.terminal_tab != current_tab_index:
                 self._move_terminal_to_tab(current_tab_index)
             self._show_terminal()
             if not self._terminal.isVisible():

--- a/glue_qt/app/tests/test_application.py
+++ b/glue_qt/app/tests/test_application.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 import numpy as np
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 
 from qtpy import QtCore
 from glue.core.data import Data
@@ -85,7 +85,44 @@ class TestGlueApplication(object):
 
     @requires_ipython
     def test_toggle_terminal(self):
-        with patch.object(self.app, '_terminal') as term:
+
+        self.app.show()
+
+        self.app._toggle_terminal()
+        assert self.app._terminal.isVisible()
+        assert self.app.terminal_tab is 0
+
+        self.app._toggle_terminal()
+        assert not self.app._terminal.isVisible()
+        assert self.app.terminal_tab is 0
+
+        self.app.new_tab()
+        self.app.tab_widget.setCurrentIndex(1)
+        assert self.app.terminal_tab is 0
+
+        self.app._toggle_terminal()
+        assert self.app._terminal.isVisible()
+        assert self.app.terminal_tab is 1
+
+        self.app._toggle_terminal()
+        assert not self.app._terminal.isVisible()
+        assert self.app.terminal_tab is 1
+
+        self.app.close_tab(1)
+        assert self.app.terminal_tab is None
+        assert self.app._terminal is not None
+        assert not self.app._terminal.isVisible()
+
+        self.app._toggle_terminal()
+        assert self.app._terminal.isVisible()
+        assert self.app.terminal_tab is 0
+
+    @requires_ipython
+    def test_terminal_warnings(self):
+        with patch.object(self.app, '_terminal') as term, \
+             patch.object(GlueApplication, 'terminal_tab', new_callable=PropertyMock) as term_tab:
+
+            term_tab.return_value = 0
 
             self.app._terminal = term
 

--- a/glue_qt/app/tests/test_application.py
+++ b/glue_qt/app/tests/test_application.py
@@ -90,23 +90,23 @@ class TestGlueApplication(object):
 
         self.app._toggle_terminal()
         assert self.app._terminal.isVisible()
-        assert self.app.terminal_tab is 0
+        assert self.app.terminal_tab == 0
 
         self.app._toggle_terminal()
         assert not self.app._terminal.isVisible()
-        assert self.app.terminal_tab is 0
+        assert self.app.terminal_tab == 0
 
         self.app.new_tab()
         self.app.tab_widget.setCurrentIndex(1)
-        assert self.app.terminal_tab is 0
+        assert self.app.terminal_tab == 0
 
         self.app._toggle_terminal()
         assert self.app._terminal.isVisible()
-        assert self.app.terminal_tab is 1
+        assert self.app.terminal_tab == 1
 
         self.app._toggle_terminal()
         assert not self.app._terminal.isVisible()
-        assert self.app.terminal_tab is 1
+        assert self.app.terminal_tab == 1
 
         self.app.close_tab(1)
         assert self.app.terminal_tab is None
@@ -115,7 +115,7 @@ class TestGlueApplication(object):
 
         self.app._toggle_terminal()
         assert self.app._terminal.isVisible()
-        assert self.app.terminal_tab is 0
+        assert self.app.terminal_tab == 0
 
     @requires_ipython
     def test_terminal_warnings(self):

--- a/glue_qt/utils/helpers.py
+++ b/glue_qt/utils/helpers.py
@@ -234,7 +234,7 @@ def is_descendant_of(descendant_widget, ancestor_widget):
     Checks if descendant_widget is a descendant (child, grandchild, etc.)
     of ancestor_widget.
     """
-    if not ancestor_widget:
+    if not (ancestor_widget and descendant_widget):
         return False
 
     current_parent = descendant_widget.parent()

--- a/glue_qt/utils/helpers.py
+++ b/glue_qt/utils/helpers.py
@@ -227,3 +227,20 @@ def qurl_to_path(url):
             path = path[1:]
 
     return path
+
+
+def is_descendant_of(descendant_widget, ancestor_widget):
+    """
+    Checks if descendant_widget is a descendant (child, grandchild, etc.)
+    of ancestor_widget.
+    """
+    if not ancestor_widget:
+        return False
+
+    current_parent = descendant_widget.parent()
+    while current_parent:
+        if current_parent == ancestor_widget:
+            return True
+        current_parent = current_parent.parent()
+
+    return False


### PR DESCRIPTION
This PR resolves #63 by allowing the terminal to change tabs, using the approach discussed in that issue. A couple of other minor pieces of this:
* I added a check each time the tab changes so that we can make the terminal button check status match the current visibility of the terminal
* If the tab with the terminal is closed, we remove the terminal first so that it can be re-added (with the same state) when summoned again