### PR TITLE
TST: cleanup tox envs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,14 +36,13 @@ jobs:
 
       envs: |
         # Standard tests
-        # Linux builds - test on all supported PyQt5/6 and PySide2/6 versions,
-        # and include all dependencies in some builds
-        - linux: py310-test-pyqt63-all
+        # Linux builds - test on all supported PyQt5/6 and PySide2/6 versions
+        - linux: py310-test-pyqt63
         - linux: py311-test-pyqt64
         - linux: py312-test-pyqt65
         - linux: py312-test-pyqt68
         - linux: py313-test-pyqt67
-        - linux: py311-test-pyqt66-all
+        - linux: py311-test-pyqt66
         - linux: py311-test-pyqt514
 
         # Documentation build
@@ -55,27 +54,25 @@ jobs:
             brew:
               - enchant
 
-        # Test a few configurations on macOS 13 (Intel, default for py<310) and 14 (Arm)
-        - macos: py310-test-pyqt515-all
-        - macos: py311-test-pyqt65
+        # Test a few configurations on macOS 15 (Arm)
+        - macos: py310-test-pyqt515
+        # Failing on timeout when pytest-qt is installed (#65)
+        - macos: py311-test-pyqt65-ignoreqt
         - macos: py312-test-pyqt66
-        - macos: py313-test-pyqt68
+        - macos: py314-test-pyqt68
 
         # Test some configurations on Windows
-        - windows: py310-test-pyqt63
-        - windows: py311-test-pyqt65
+        # Ignore failures from the Qt widget with older Qt6 versions (#65)
+        - windows: py310-test-pyqt63-ignoreqt
+        - windows: py311-test-pyqt65-ignoreqt
         - windows: py312-test-pyqt67
-        - windows: py313-test-pyqt67
+        - windows: py313-test-pyqt68
 
         # Test against latest developer versions of some packages
         - linux: py311-test-pyqt64-dev
-        - linux: py312-test-pyqt515-dev-all
-        - linux: py312-test-pyqt67-dev
-        # Test against latest developer versions of some packages
-        - linux: py311-test-pyqt64-dev
-        - linux: py312-test-pyqt515-dev-all
+        - linux: py312-test-pyqt515-dev
         - linux: py313-test-pyqt67-dev
-        - linux: py314-test-pyqt68-dev-all
+        - linux: py314-test-pyqt68-dev
 
   allowed_failures:
     needs: initial_checks
@@ -119,7 +116,7 @@ jobs:
           coverage: false
 
         # Failure in test_close_tab
-        - windows: py310-test-pyqt515-all
+        - windows: py310-test-pyqt515
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -37,18 +37,18 @@ jobs:
       envs: |
         # Standard tests
         # Linux builds - test on all supported PyQt5/6 and PySide2/6 versions
-        - linux: py310-test-pyqt63
-        - linux: py311-test-pyqt64
-        - linux: py312-test-pyqt65
-        - linux: py312-test-pyqt68
-        - linux: py313-test-pyqt67
         - linux: py311-test-pyqt66
+        - linux: py313-test-pyqt67
+        - linux: py312-test-pyqt68
+        - linux: py313-test-pyqt69
+        - linux: py314-test-pyqt610
+        - linux: py312-test-pyqt611
         - linux: py311-test-pyqt514
 
         # Documentation build
-        - linux: py311-docs-pyqt514
+        - linux: py311-docs-pyqt66
           coverage: false
-        - macos: py314-docs-pyqt67
+        - macos: py314-docs-pyqt611
           coverage: false
           libraries:
             brew:
@@ -56,23 +56,20 @@ jobs:
 
         # Test a few configurations on macOS 15 (Arm)
         - macos: py310-test-pyqt515
-        # Failing on timeout when pytest-qt is installed (#65)
-        - macos: py311-test-pyqt65-ignoreqt
-        - macos: py312-test-pyqt66
-        - macos: py314-test-pyqt68
+        - macos: py311-test-pyqt66
+        - macos: py313-test-pyqt69
+        - macos: py314-test-pyqt611
 
         # Test some configurations on Windows
-        # Ignore failures from the Qt widget with older Qt6 versions (#65)
-        - windows: py310-test-pyqt63-ignoreqt
-        - windows: py311-test-pyqt65-ignoreqt
         - windows: py312-test-pyqt67
         - windows: py313-test-pyqt68
+        - windows: py314-test-pyqt610
 
         # Test against latest developer versions of some packages
-        - linux: py311-test-pyqt64-dev
         - linux: py312-test-pyqt515-dev
-        - linux: py313-test-pyqt67-dev
+        - linux: py311-test-pyqt67-dev
         - linux: py314-test-pyqt68-dev
+        - linux: py314-test-pyqt611-dev
 
   allowed_failures:
     needs: initial_checks
@@ -91,32 +88,24 @@ jobs:
           - enchant
           - hdf5
       envs: |
-
-        # Non-deterministic QThread exceptions
-        - linux: py310-test-pyside63-skipexitcode
-
-        # PySide6 6.4 failures due to https://github.com/spyder-ide/qtpy/issues/373
-        # and https://github.com/matplotlib/matplotlib/issues/24155
-        # PyQt5 / < 6.6 segfaulting under macOS 14 (on arm64) in TestGlueDataDialog or TestLinkEditor
         # Python 3.11.0 failing on Windows in test_image.py on
         # > assert df.find_factory(fname) is df.img_data
-        - linux: py311-test-pyside64-skipexitcode
         - linux: py312-test-pyside66-skipexitcode
-        - linux: py313-test-pyside68-skipexitcode
-        - macos: py310-test-pyside63-skipexitcode
-        - macos: py311-test-pyside64-skipexitcode
-        - macos: py312-test-pyside68-skipexitcode
-        - macos: py310-test-pyqt515
-        - windows: py310-test-pyside64
+        - linux: py313-test-pyside69
+        - linux: py314-test-pyside611
+        - macos: py312-test-pyside68
+        - macos: py314-test-pyside610
+        - macos: py313-test-pyqt515
         - windows: py312-test-pyside67
+        - windows: py313-test-pyside611
         - windows: py311-test-pyqt515
 
         # Windows docs build
-        - windows: py310-docs-pyqt515
+        - windows: py311-docs-pyqt515
           coverage: false
 
         # Failure in test_close_tab
-        - windows: py310-test-pyqt515
+        - windows: py311-test-pyqt515
 
   publish:
     needs: tests

--- a/glue_qt/tests/helpers.py
+++ b/glue_qt/tests/helpers.py
@@ -22,8 +22,10 @@ requires_pyside = pytest.mark.skipif(str(not PYSIDE_INSTALLED),
 requires_qt = pytest.mark.skipif(str(not QT_INSTALLED),
                                  reason='An installation of Qt is required')
 
-PYQT_GT_59, _ = make_skipper('PyQt5', version='5.10')
+PYQT5_GT_59, _ = make_skipper('PyQt5', version='5.10')
 
-requires_pyqt_gt_59_or_pyside = pytest.mark.skipif(str(not (PYQT_GT_59 or PYQT6_INSTALLED or
+PYQT6_GT_68, _ = make_skipper('PyQt6', version='6.9')
+
+requires_pyqt_gt_59_or_pyside = pytest.mark.skipif(str(not (PYQT5_GT_59 or PYQT6_INSTALLED or
                                                             PYSIDE_INSTALLED)),
                                                    reason='Requires PyQt > 5.9 or PySide2/6')

--- a/glue_qt/viewers/common/tests/test_data_viewer.py
+++ b/glue_qt/viewers/common/tests/test_data_viewer.py
@@ -104,6 +104,8 @@ class BaseTestDataViewer(object):
         w.state.title = "My Viewer"
         assert w.parent().windowTitle() == "My Viewer"
 
+        app.close()
+
     def test_viewer_title_tool(self):
 
         # check that the viewer title tool correctly updates the title
@@ -119,6 +121,8 @@ class BaseTestDataViewer(object):
             tool.activate()
         assert w.state.title == "My Viewer"
         assert w.parent().windowTitle() == "My Viewer"
+
+        app.close()
 
 
 class TestDataViewerScatter(BaseTestDataViewer):

--- a/glue_qt/viewers/matplotlib/tests/test_data_viewer.py
+++ b/glue_qt/viewers/matplotlib/tests/test_data_viewer.py
@@ -19,7 +19,7 @@ from glue_qt.app.application import GlueApplication
 from glue.core.roi import XRangeROI
 from glue_qt.utils import process_events
 from glue.tests.helpers import requires_matplotlib_ge_22
-from glue_qt.tests.helpers import requires_pyqt, PYQT5_INSTALLED
+from glue_qt.tests.helpers import requires_pyqt, PYQT5_INSTALLED, PYQT6_GT_68
 
 
 class MatplotlibDrawCounter(object):
@@ -595,9 +595,12 @@ class BaseTestMatplotlibDataViewer(object):
         self.viewer.figure.canvas.draw()
         process_events(wait=0.1)
 
-        # Broken in Linux CI with PyQT5
-        if not (PYQT5_INSTALLED and sys.platform == 'linux'):
-            assert not np.allclose(limits(self.viewer), initial_limits, rtol=1e-7, atol=0)
+        # Broken in Linux CI with PyQT5 and PyQT6 >= 6.9
+        if (PYQT5_INSTALLED or PYQT6_GT_68) and sys.platform == 'linux':
+            frozen = True
+        else:
+            frozen = False
+        assert np.allclose(limits(self.viewer), initial_limits, rtol=1e-7, atol=0) is frozen
 
         # Now change the viewer size a number of times and make sure if we
         # return to the original size, the limits match the initial ones.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-faulthandler",
-    "pytest-flake8",
     "objgraph",
    ]
 
@@ -103,10 +102,6 @@ version_file = "glue_qt/_version.py"
 
 [tool.pytest.ini_options]
 addopts = "-p no:logging"
-# Legacy ignores?
-# E402, E741 (permanently) in ruff lint.ignore
-# E402, E501, F841, W605 (temporarily) in .ruff.toml
-flake8-ignore = "E226,E501,E731,F841,E127,E741,E402,W504,W605"
 filterwarnings = [
     "ignore::PendingDeprecationWarning:xlrd",
     "ignore:Session._key_changed is deprecated",

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,6 @@ deps =
     all: pytest-qt
 extras =
     test
-    all: all
     docs: docs
 allowlist_externals =
     sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-{dev,ignoreqt}
+    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt66,pyqt67,pyqt68,pyqt69,pyqt610,pyqt611,pyside66,pyside67,pyside68,pyside69,pyside610,pyside611}-{dev,ignoreqt}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -24,26 +24,26 @@ changedir =
 deps =
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
-    pyqt63: PyQt6==6.3.*
-    pyqt63: PyQt6-Qt6==6.3.*
-    pyqt64: PyQt6==6.4.*
-    pyqt64: PyQt6-Qt6==6.4.*
-    pyqt65: PyQt6-Qt6==6.5.*
-    pyqt65: PyQt6==6.5.*
     pyqt66: PyQt6-Qt6==6.6.*
     pyqt66: PyQt6==6.6.*
     pyqt67: PyQt6-Qt6==6.7.*
     pyqt67: PyQt6==6.7.*
     pyqt68: PyQt6-Qt6==6.8.*
     pyqt68: PyQt6==6.8.*
+    pyqt69: PyQt6-Qt6==6.9.*
+    pyqt69: PyQt6==6.9.*
+    pyqt610: PyQt6-Qt6==6.10.*
+    pyqt610: PyQt6==6.10.*
+    pyqt611: PyQt6-Qt6==6.11.*
+    pyqt611: PyQt6==6.11.*
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
-    pyside63: PySide6==6.3.*
-    pyside64: PySide6==6.4.*
-    pyside65: PySide6==6.5.*
     pyside66: PySide6==6.6.*
     pyside67: PySide6==6.7.*
     pyside68: PySide6==6.8.*
+    pyside69: PySide6==6.9.*
+    pyside610: PySide6==6.10.*
+    pyside611: PySide6==6.11.*
     dev: numpy>=0.0.dev0
     dev: scipy>=0.0.dev0
     dev: astropy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-all-{dev}
+    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-{dev,ignoreqt}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -50,7 +50,8 @@ deps =
     dev: git+https://github.com/glue-viz/glue
     # Fix from https://github.com/pyenchant/pyenchant/pull/302 to find newer Homebrew installations
     docs: pyenchant>=3.3.0rc1
-    all: pytest-qt
+    # Run standard tests only with pytest-qt installed, which will raise on exceptions caught in Qt event loop.
+    !docs-!ignoreqt: pytest-qt
 extras =
     test
     docs: docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-all-{dev,legacy}
+    py{310,311,312,313,314}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside66,pyside67,pyside68}-all-{dev}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -50,22 +50,6 @@ deps =
     dev: git+https://github.com/glue-viz/glue
     # Fix from https://github.com/pyenchant/pyenchant/pull/302 to find newer Homebrew installations
     docs: pyenchant>=3.3.0rc1
-    legacy: numpy==1.17.*
-    legacy: matplotlib==3.2.*
-    legacy: scipy==1.1.*
-    legacy: pandas==1.2.*
-    legacy: echo==0.5.*
-    legacy: astropy==4.0.*
-    legacy: setuptools==30.3.*
-    legacy: qtpy==1.9.*
-    legacy: ipython==7.16.*
-    legacy: ipykernel==5.3.*
-    legacy: qtconsole==4.3.*
-    legacy: dill==0.2.*
-    legacy: xlrd==1.2.*
-    legacy: h5py==2.10.*
-    legacy: mpl-scatter-density==0.7.*
-    legacy: openpyxl==3.0.*
     all: pytest-qt
 extras =
     test


### PR DESCRIPTION
## Description
Some time in the last weeks the `-all` test runs started to fail with a pip error on [trying to install the `all` extra](https://github.com/glue-viz/glue-qt/actions/runs/22106772802/job/63891832787) – in  fact this extra has not existed in a long while(forever?). In my experience pip would just silently ignore nonexistent extras, so I can only suspect a recent update in the tox/pip configuration has turned this into a failure. Anyway it's at best confusing to have this listed in tox.ini, so the first commit is removing that. This leaves as only extra package installed under the "all" env `pytest-qt` – does anyone know if this has even any effect on the tests run (number of passed tests unchanged; according to the description its main function is the `qtbot` fixture which we don't use)? Otherwise might remove the `-all` jobs altogether or turn them into plain ones.

Second commit also removes the `legacy` env, which at this point only includes versions long abandoned by our Python versions.